### PR TITLE
[GMMS-2542] Force statusbar to dark content to make it visible in lig…

### DIFF
--- a/GCMessengerSDKSample/GCMessengerSDKSample/AccountDetailsViewController.swift
+++ b/GCMessengerSDKSample/GCMessengerSDKSample/AccountDetailsViewController.swift
@@ -131,7 +131,7 @@ class AccountDetailsViewController: UIViewController {
     private func openMainController(with account: MessengerAccount) {
         let controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ChatWrapperViewController") as! ChatWrapperViewController
         controller.messengerAccount = account
-        
+        controller.modalPresentationCapturesStatusBarAppearance = true
         present(controller, animated: true)
     }
 }

--- a/GCMessengerSDKSample/GCMessengerSDKSample/ChatWrapperViewController.swift
+++ b/GCMessengerSDKSample/GCMessengerSDKSample/ChatWrapperViewController.swift
@@ -53,6 +53,10 @@ class ChatWrapperViewController: UIViewController {
         
         view?.addSubview(activityView)
     }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .darkContent
+    }
 }
 
 extension ChatWrapperViewController: ChatControllerDelegate {

--- a/GCMessengerSDKSample/GCMessengerSDKSample/Info.plist
+++ b/GCMessengerSDKSample/GCMessengerSDKSample/Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
At this moment we support light mode only in SDK, dark mode will come later. Until then we force the status bar content to dark, to make the clock, battery etc. visible on the white background. 