### PR TITLE
[GMMS-3985] Have some delay on toast while tableview scrolls.

### DIFF
--- a/GCMessengerSDKSample/GCMessengerSDKSample/Helper/Toast.swift
+++ b/GCMessengerSDKSample/GCMessengerSDKSample/Helper/Toast.swift
@@ -40,12 +40,12 @@ public class ToastManager {
                 NSLayoutConstraint.activate([horizontalCenterConstraint, widthConstraint])
                 NSLayoutConstraint.activate(verticalConstraint)
     
-                UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseIn, animations: {
+                UIView.animate(withDuration: 0.5, delay: 0.8, options: .curveEaseIn, animations: {
                     toastView.alpha = 1
                 }, completion: nil)
 
                 // Automatically hide the toast after a delay
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) {
                     UIView.animate(withDuration: 0.5, animations: {
                         toastView.alpha = 0
                     }, completion: { _ in


### PR DESCRIPTION
The longMessage test may fail, because the toast animation can stop the tableview animation. This fix makes the toast message to wait until the scroll is done. 
From user experience it is also better, because user can see the error status icon and the message at once.