### PR TITLE
[GMMS-6457] Fixed a bug where sample application wouldn't open clicked URLs in the browser.

### DIFF
--- a/GCMessengerSDKSample/GCMessengerSDKSample/ChatWrapperViewController.swift
+++ b/GCMessengerSDKSample/GCMessengerSDKSample/ChatWrapperViewController.swift
@@ -200,5 +200,8 @@ extension ChatWrapperViewController: ChatControllerDelegate {
     
     func didClickLink(_ url: String) {
         print("Link \(url) was pressed in the chat")
+        if let url = URL(string: url) {
+            UIApplication.shared.open(url)
+        }
     }
 }


### PR DESCRIPTION
Because of the changes in the didClickLink delegate, if the delegate is used then the SDK no longer opens the URL and delegates this responsibility to the host application. If the delegate is not used however, everything remains the same.